### PR TITLE
Remove distinct(matricula) from conecta

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sistec
 Type: Package
 Title: Tools to Analyze 'Sistec' Datasets
-Version: 0.2.0.9010
+Version: 0.2.0.9011
 Authors@R: c(
     person("Samuel", "Macêdo", email = "samuelmacedo@recife.ifpe.edu.br", role = c("aut", "cre")),
     person("Carlos", "Patrício", email = "carlos.patricio@vitoria.ifpe.edu.br", role = "aut"),

--- a/R/merge_sistec_rfept.R
+++ b/R/merge_sistec_rfept.R
@@ -1,83 +1,86 @@
-merge_sistec_rfept <- function(x){
-
+merge_sistec_rfept <- function(x) {
   x$sistec_rfept_linked <- dplyr::inner_join(x$sistec, x$rfept,
-                                             by = c("S_NU_CPF" = "R_NU_CPF")) %>% 
-    link_courses() %>% 
-    link_ciclos() %>% 
-    remove_duplicated_courses() %>% 
+    by = c("S_NU_CPF" = "R_NU_CPF")
+  ) %>%
+    link_courses() %>%
+    link_ciclos() %>%
+    remove_duplicated_courses() %>%
     remove_duplicated_link()
 
   x$sistec <- dplyr::anti_join(x$sistec, x$sistec_rfept_linked,
-                               by = c("S_NU_CPF", "S_CO_CICLO_MATRICULA"))
-  
-    
-  x$rfept <- dplyr::anti_join(x$rfept, x$sistec_rfept_linked, 
-                              by = c("R_NU_CPF" = "S_NU_CPF", "R_CO_MATRICULA"))
-    
+    by = c("S_NU_CPF", "S_CO_CICLO_MATRICULA")
+  )
+
+
+  x$rfept <- dplyr::anti_join(x$rfept, x$sistec_rfept_linked,
+    by = c("R_NU_CPF" = "S_NU_CPF", "R_CO_MATRICULA")
+  )
+
   x
 }
 
 #' @importFrom dplyr %>% sym
-link_courses <- function(x){
-  # to link a course, they must initiate at the same time and 
+link_courses <- function(x) {
+  # to link a course, they must initiate at the same time and
   # have the majority of the students point to the same course
-  
-  x <- x %>% 
+
+  x <- x %>%
     dplyr::filter(!!sym("R_DT_INICIO_CURSO") == !!sym("S_DT_INICIO_CURSO"))
-  
-  x %>% 
-    dplyr::group_by(!!sym("R_NO_CURSO"), !!sym("S_NO_CURSO")) %>% 
-    dplyr::tally() %>% 
-    dplyr::filter(!!sym("n") > 10) %>% 
-    dplyr::rename(S_NO_CURSO_LINKED = !!sym("S_NO_CURSO"), S_QT_ALUNOS_LINKED = !!sym("n")) %>% 
-    dplyr::inner_join(x, by = "R_NO_CURSO") %>% 
-    dplyr::filter(!!sym("S_NO_CURSO_LINKED") == !!sym("S_NO_CURSO")) %>% 
+
+  x %>%
+    dplyr::group_by(!!sym("R_NO_CURSO"), !!sym("S_NO_CURSO")) %>%
+    dplyr::tally() %>%
+    dplyr::filter(!!sym("n") > 10) %>%
+    dplyr::rename(
+      S_NO_CURSO_LINKED = !!sym("S_NO_CURSO"),
+      S_QT_ALUNOS_LINKED = !!sym("n")
+    ) %>%
+    dplyr::inner_join(x, by = "R_NO_CURSO") %>%
+    dplyr::filter(!!sym("S_NO_CURSO_LINKED") == !!sym("S_NO_CURSO")) %>%
     dplyr::ungroup()
 }
 
 #' @importFrom dplyr %>% sym
-link_ciclos <- function(x){
+link_ciclos <- function(x) {
   # sometimes a same ciclo can point to different courses in rfept, choose
   # that ciclo with the majority of students
 
   ciclos <- x %>%
     dplyr::group_by(!!sym("S_CO_CICLO_MATRICULA"), !!sym("S_QT_ALUNOS_LINKED")) %>%
     dplyr::tally() %>%
-    dplyr::arrange(!!sym("S_CO_CICLO_MATRICULA") , dplyr::desc(!!sym("n"))) %>%
+    dplyr::arrange(!!sym("S_CO_CICLO_MATRICULA"), dplyr::desc(!!sym("n"))) %>%
     dplyr::distinct(!!sym("S_CO_CICLO_MATRICULA"), .keep_all = TRUE)
-  
+
   dplyr::semi_join(x, ciclos, by = c("S_CO_CICLO_MATRICULA", "S_QT_ALUNOS_LINKED"))
 }
 
-remove_duplicated_courses <- function(x){
+remove_duplicated_courses <- function(x) {
   courses <- x %>%
-    dplyr::group_by(!!sym("R_NO_CURSO"), !!sym("S_NO_CURSO")) %>% 
-    dplyr::tally() %>% 
-    dplyr::filter(!!sym("n") > 8) # this number is empirical. 
+    dplyr::group_by(!!sym("R_NO_CURSO"), !!sym("S_NO_CURSO")) %>%
+    dplyr::tally() %>%
+    dplyr::filter(!!sym("n") > 8) # this number is empirical.
   # I didn't find other examples less than 8
-  
-  dplyr::semi_join(x, courses, by = c("R_NO_CURSO", "S_NO_CURSO")) 
+
+  dplyr::semi_join(x, courses, by = c("R_NO_CURSO", "S_NO_CURSO"))
 }
 
 #' @importFrom dplyr %>% sym
-remove_duplicated_link <- function(x){
-  
-  
-  
-  duplicated_link <- x %>% 
+remove_duplicated_link <- function(x) {
+  duplicated_link <- x %>%
     dplyr::group_by(!!sym("S_NU_CPF"), !!sym("R_CO_MATRICULA")) %>%
-    dplyr::tally() %>% 
+    dplyr::tally() %>%
     dplyr::filter(!!sym("n") > 1)
-  
+
   dplyr::anti_join(x, duplicated_link, by = c("S_NU_CPF", "R_CO_MATRICULA"))
 }
 
 
 #' @importFrom dplyr sym
-complete_campus <- function(x){
+complete_campus <- function(x) {
   # some student registraion doesn't have information about campus
   # we complete this part using information in sistec
   dplyr::mutate(x, R_NO_CAMPUS = ifelse(!!sym("R_NO_CAMPUS") == "SEM CAMPUS",
-                                        !!sym("S_NO_CAMPUS"),
-                                        !!sym("R_NO_CAMPUS")))
+    !!sym("S_NO_CAMPUS"),
+    !!sym("R_NO_CAMPUS")
+  ))
 }

--- a/R/read_conecta.R
+++ b/R/read_conecta.R
@@ -1,65 +1,72 @@
 #' Read Conecta files
 #'
-#' This function supports two kinds of schemas: from the api and the website. See Details 
+#' This function supports two kinds of schemas: from the api and the website. See Details
 #' if you need help to download the Conecta data.
 #'
-#' @param path The Conecta file's path. 
-#' @param start A character with the date to start the comparison. The default is the minimum 
+#' @param path The Conecta file's path.
+#' @param start A character with the date to start the comparison. The default is the minimum
 #' value found in the data. The date has to be in this format: "yyyy.semester".
 #' Ex.: "2019.1" or "2019.2".
 #' @return A data frame.
-#' 
-#' @importFrom dplyr %>% sym 
+#'
+#' @importFrom dplyr %>% sym
 #' @export
-read_conecta <- function(path = "", start = NULL){
-  
-  if(path == "") stop("You need to specify the path.")
-  
-  temp <-  list.files(path = path, pattern = "*.csv")
-  temp <- paste0(path , "/", temp) %>% sort(decreasing = TRUE)
-  
-  conecta <- utils::read.csv(temp[1], sep = ";",  stringsAsFactors = FALSE, 
-                             encoding = "latin1", nrows = 1, check.names = FALSE)
-  
-  
-  vars <- c("RA", "NOME_ALUNO", "STATUS_NO_CURSO", "Cota Chamado",
-            "NOME_CURSO", "CPF", "NOME_CAMPUS", "DATA_INGRESSO_CURSO")
-  
-  if(sum(names(conecta) %in% vars) == 8){
+read_conecta <- function(path = "", start = NULL) {
+  if (path == "") stop("You need to specify the path.")
+
+  temp <- list.files(path = path, pattern = "*.csv")
+  temp <- paste0(path, "/", temp) %>% sort(decreasing = TRUE)
+
+  conecta <- utils::read.csv(temp[1],
+    sep = ";", stringsAsFactors = FALSE,
+    encoding = "latin1", nrows = 1, check.names = FALSE
+  )
+
+
+  vars <- c(
+    "RA", "NOME_ALUNO", "STATUS_NO_CURSO", "Cota Chamado",
+    "NOME_CURSO", "CPF", "NOME_CAMPUS", "DATA_INGRESSO_CURSO"
+  )
+
+  if (sum(names(conecta) %in% vars) == 8) {
     conecta <- read_conecta_web(path)
-  } else{
-    stop(paste("Not found:",
-               paste(vars[!vars %in% names(conecta)], collapse = ", ")))
+  } else {
+    stop(paste(
+      "Not found:",
+      paste(vars[!vars %in% names(conecta)], collapse = ", ")
+    ))
   }
-  
+
   conecta <- filter_rfept_date(conecta, start)
   conecta
 }
 
 #' @importFrom dplyr %>% sym
-read_conecta_web <- function(path){
-  temp <-  list.files(path = path, pattern = "*.csv")
-  temp <- paste0(path , "/", temp) %>% sort(decreasing = TRUE)
-  
+read_conecta_web <- function(path) {
+  temp <- list.files(path = path, pattern = "*.csv")
+  temp <- paste0(path, "/", temp) %>% sort(decreasing = TRUE)
+
   classes <- "character"
-  
-  conecta <- lapply(temp,  utils::read.csv,
-                       sep = ";",  stringsAsFactors = FALSE, colClasses = classes,
-                       encoding = "latin1", check.names = FALSE) %>% 
-    dplyr::bind_rows() %>% 
-    dplyr::distinct(!!sym("RA"), .keep_all = TRUE) %>% # Take the most recent 
-    dplyr::transmute(R_NO_ALUNO = !!sym("NOME_ALUNO"),
-                     R_NU_CPF = num_para_cpf(!!sym("CPF")),
-                     R_CO_MATRICULA = !!sym("RA"),
-                     R_CO_CICLO_MATRICULA = "", # unitl now a RFEPT doesn't have ciclo
-                     R_NO_STATUS_MATRICULA = !!sym("STATUS_NO_CURSO"),
-                     R_NO_CURSO = correct_course_name(!!sym("NOME_CURSO")),
-                     R_DT_INICIO_CURSO = conecta_convert_beginning_date(!!sym("DATA_INGRESSO_CURSO")),
-                     R_NO_CAMPUS = !!sym("NOME_CAMPUS"),
-                     R_NO_COTA = conecta_cota(!!sym("Cota Chamado")))
-  
+
+  conecta <- lapply(temp, utils::read.csv,
+    sep = ";", stringsAsFactors = FALSE, colClasses = classes,
+    encoding = "latin1", check.names = FALSE
+  ) %>%
+    dplyr::bind_rows() %>%
+    dplyr::transmute(
+      R_NO_ALUNO = !!sym("NOME_ALUNO"),
+      R_NU_CPF = num_para_cpf(!!sym("CPF")),
+      R_CO_MATRICULA = !!sym("RA"),
+      R_CO_CICLO_MATRICULA = "", # unitl now a RFEPT doesn't have ciclo
+      R_NO_STATUS_MATRICULA = !!sym("STATUS_NO_CURSO"),
+      R_NO_CURSO = correct_course_name(!!sym("NOME_CURSO")),
+      R_DT_INICIO_CURSO = conecta_convert_beginning_date(!!sym("DATA_INGRESSO_CURSO")),
+      R_NO_CAMPUS = !!sym("NOME_CAMPUS"),
+      R_NO_COTA = conecta_cota(!!sym("Cota Chamado"))
+    )
+
   class(conecta) <- c("rfept_data_frame", "conecta_table", class(conecta))
-  
+
   conecta
 }
 
@@ -68,18 +75,21 @@ read_conecta_web <- function(path){
 #   stringr::str_trim(course)
 # }
 
-conecta_convert_beginning_date <- function(date){
-  
+conecta_convert_beginning_date <- function(date) {
   year <- stringr::str_sub(date, 7, 10)
   month <- as.numeric(stringr::str_sub(date, 4, 5))
-  
-  year_semester <- paste0(year, ".",
-                          ifelse(month <= 6, 1, 2))
+
+  year_semester <- paste0(
+    year, ".",
+    ifelse(month <= 6, 1, 2)
+  )
   ifelse(year_semester == "NA.NA", "SEM DATA", year_semester)
 }
 
-conecta_cota <- function(cota){
-  dplyr::if_else(grepl("A0|AC", cota) | cota == "",
-                 "N\u00c3O COTISTA",
-                 "COTISTA")
+conecta_cota <- function(cota) {
+  dplyr::if_else(
+    grepl("A0|AC", cota) | cota == "",
+    "N\u00c3O COTISTA",
+    "COTISTA"
+  )
 }

--- a/test.R
+++ b/test.R
@@ -1,3 +1,56 @@
+
+rfept<- read_rfept("C:/Users/dmmad/Desktop/ARIA-testes/formiga/conecta/") 
+sistec <- read_sistec("C:/Users/dmmad/Desktop/ARIA-testes/formiga/sistec/")
+d <- compare_sistec(sistec, rfept)
+write_output(d, "C:/Users/dmmad/Desktop/ARIA2/")
+
+
+a <- read.csv("C:/Users/dmmad/Desktop/ARIA-testes/sistec_csv_COM_cpf.csv", sep = ";")
+
+a %>%
+  select(NO_CICLO_MATRICULA, DT_DATA_INICIO, DT_DATA_FIM_PREVISTO, NO_STATUS_MATRICULA) %>% 
+  mutate(NO_CURSO = sistec:::sistec_course_name(NO_CICLO_MATRICULA),
+         DT_RETENCAO_ANO = 1 + as.numeric(substr(DT_DATA_FIM_PREVISTO, 1,4)),
+         DT_RETENCAO_MES = as.numeric(substr(DT_DATA_FIM_PREVISTO, 6,7)),
+         DT_ATUAL_ANO = as.numeric(substr(Sys.Date(), 1,4)),
+         DT_ATUAL_MES = as.numeric(substr(Sys.Date(), 6,7))) %>% 
+  mutate(TEMPO_EM_CURSO = 12 * (DT_ATUAL_ANO - DT_RETENCAO_ANO) + DT_ATUAL_MES - DT_RETENCAO_MES) %>% 
+  filter(TEMPO_EM_CURSO >= 12, NO_STATUS_MATRICULA == "EM_CURSO") %>% 
+  select(-DT_DATA_INICIO, -DT_DATA_FIM_PREVISTO, -NO_CICLO_MATRICULA) %>% 
+  mutate(STATUS = "RETIDO") 
+
+
+
+sigaa <- read.csv("C:/Users/dmmad/Desktop/ARIA-testes/ifsulminas/sigaa/SIGAA (teste1) samuel.csv",
+              sep = ";")
+class(sigaa) <- c("rfept_data_frame", "generic_rfept_table", class(sigaa))
+names(sigaa) <- paste0("R_",names(sigaa)) 
+sigaa$R_NU_CPF <- paste0("000.000.000-", sigaa$R_NU_CPF)
+sigaa$R_CO_CICLO_MATRICULA <- ""
+
+
+sigaa$R_DT_INICIO_CURSO <- as.character(sigaa$R_DT_INICIO_CURSO)
+sigaa$R_CO_MATRICULA <- as.character(sigaa$R_CO_MATRICULA)
+
+sistec <- read.csv("C:/Users/dmmad/Desktop/ARIA-testes/ifsulminas/sistec/SISTEC (teste 1) samuel.csv",
+              sep = ";")
+sistec$NO_ALUNO <- rep("aaaaa", nrow(sistec))
+sistec$NU_CPF <- floor(runif(nrow(sistec), 0, 1) * 100)
+write.table(sistec, "sistec.csv", row.names = FALSE, sep = ";")
+
+sistec <- read_sistec("C:/Users/dmmad/Desktop/ARIA-testes/ifsulminas/sistec")
+
+names(sistec) <- paste0("S_",names(sistec)) 
+sistec <- sistec %>% 
+  mutate()
+
+
+d <- compare_sistec(sistec, sigaa)
+
+
+caminho <- paste0("C:/Users/dmmad/Desktop/ARIA-testes/ifsulminas/",
+                  a$NO_CAMPUS %>% unique())
+
 options(shiny.sanitize.errors = TRUE)
 
 sistec <- read_sistec("C:/Users/dmmad/Desktop/ARIA-testes/sem_unidade_ensino/")


### PR DESCRIPTION
In ifmg, there are cases where is permitted a student with two courses has the same id number ("matricula"). 
That is why I removed `dplyr::distinct(Matricula)` from the data. These students will be redirected to "manual pending".